### PR TITLE
feat: add code-server image with Cloudflare Tunnel

### DIFF
--- a/images/code-server/Dockerfile
+++ b/images/code-server/Dockerfile
@@ -1,0 +1,58 @@
+FROM debian:12-slim
+
+LABEL maintainer="lyc <imyikong@gmail.com>"
+LABEL description="code-server with dev extensions and Cloudflare Tunnel"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssh-server \
+    curl \
+    ca-certificates \
+    git \
+    sudo \
+    wget \
+    gnupg \
+    python3 \
+    python3-pip \
+    golang-go \
+    && curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg -o /usr/share/keyrings/cloudflare-main.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared bookworm main" \
+    > /etc/apt/sources.list.d/cloudflared.list \
+    && apt-get update \
+    && apt-get install -y cloudflared \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://code-server.dev/install.sh | sh
+
+RUN mkdir -p /run/sshd \
+    && sed -i 's/#*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    && sed -i 's/#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config \
+    && ssh-keygen -A
+
+RUN code-server \
+    --install-extension golang.go \
+    --install-extension ms-python.python \
+    --install-extension dbaeumer.vscode-eslint \
+    --install-extension esbenp.prettier-vscode \
+    --install-extension yzhang.markdown-all-in-one \
+    --install-extension GitHub.copilot \
+    --install-extension GitHub.copilot-chat \
+    --install-extension opencode.opencode \
+    || true
+
+# TUNNEL_TOKEN       - Cloudflare Tunnel token (required)
+# SSH_PASSWORD       - Root SSH password (default: changeme)
+# CS_PASSWORD        - code-server password (default: changeme)
+# CS_PORT            - code-server listen port (default: 8080)
+ENV TUNNEL_TOKEN="" \
+    SSH_PASSWORD="changeme" \
+    CS_PASSWORD="changeme" \
+    CS_PORT="8080"
+
+COPY entry.sh /entry.sh
+RUN chmod +x /entry.sh
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD pgrep cloudflared > /dev/null && pgrep code-server > /dev/null || exit 1
+
+ENTRYPOINT ["/entry.sh"]

--- a/images/code-server/Dockerfile
+++ b/images/code-server/Dockerfile
@@ -3,6 +3,8 @@ FROM debian:12-slim
 LABEL maintainer="lyc <imyikong@gmail.com>"
 LABEL description="code-server with dev extensions and Cloudflare Tunnel"
 
+ARG CODE_SERVER_VERSION=4.108.2
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-server \
     curl \
@@ -11,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo \
     wget \
     gnupg \
+    netcat-openbsd \
     python3 \
     python3-pip \
     golang-go \
@@ -22,11 +25,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://code-server.dev/install.sh | sh
+RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version=${CODE_SERVER_VERSION}
+
+RUN groupadd -g 1001 coder \
+    && useradd -m -u 1001 -g 1001 -s /bin/bash coder \
+    && echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 RUN mkdir -p /run/sshd \
-    && sed -i 's/#*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config \
-    && sed -i 's/#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config \
+    && sed -i 's/#*PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config \
+    && sed -i 's/#*PubkeyAuthentication.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config \
     && ssh-keygen -A
 
 RUN code-server \
@@ -37,22 +44,23 @@ RUN code-server \
     --install-extension yzhang.markdown-all-in-one \
     --install-extension GitHub.copilot \
     --install-extension GitHub.copilot-chat \
-    --install-extension opencode.opencode \
-    || true
+    --install-extension opencode.opencode
 
 # TUNNEL_TOKEN       - Cloudflare Tunnel token (required)
-# SSH_PASSWORD       - Root SSH password (default: changeme)
-# CS_PASSWORD        - code-server password (default: changeme)
+# SSH_PASSWORD       - SSH password for coder user (optional, at least one of SSH_PASSWORD/SSH_AUTHORIZED_KEYS required)
+# SSH_AUTHORIZED_KEYS - SSH public keys for coder user (optional)
+# CS_PASSWORD        - code-server password (required)
 # CS_PORT            - code-server listen port (default: 8080)
 ENV TUNNEL_TOKEN="" \
-    SSH_PASSWORD="changeme" \
-    CS_PASSWORD="changeme" \
+    SSH_PASSWORD="" \
+    SSH_AUTHORIZED_KEYS="" \
+    CS_PASSWORD="" \
     CS_PORT="8080"
 
 COPY entry.sh /entry.sh
 RUN chmod +x /entry.sh
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD pgrep cloudflared > /dev/null && pgrep code-server > /dev/null || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD curl -fsS -o /dev/null http://localhost:${CS_PORT}/healthz && nc -z localhost 22 || exit 1
 
 ENTRYPOINT ["/entry.sh"]

--- a/images/code-server/entry.sh
+++ b/images/code-server/entry.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+if [ -z "${TUNNEL_TOKEN}" ]; then
+    echo "❌ Error: TUNNEL_TOKEN is required"
+    echo "Get it from Cloudflare Zero Trust dashboard or 'cloudflared tunnel create'"
+    exit 1
+fi
+
+SSH_PASSWORD=${SSH_PASSWORD:-changeme}
+CS_PASSWORD=${CS_PASSWORD:-changeme}
+CS_PORT=${CS_PORT:-8080}
+
+echo "root:${SSH_PASSWORD}" | chpasswd
+
+sed -i "s/#*Port .*/Port 22/" /etc/ssh/sshd_config
+
+echo "🚀 Starting SSH server..."
+/usr/sbin/sshd
+
+echo "🖥️ Starting code-server on port ${CS_PORT}..."
+PASSWORD="${CS_PASSWORD}" code-server \
+    --bind-addr "0.0.0.0:${CS_PORT}" \
+    --auth password \
+    --disable-telemetry &
+
+echo "🌐 Starting Cloudflare Tunnel..."
+exec cloudflared tunnel --no-autoupdate run --token "${TUNNEL_TOKEN}"

--- a/images/code-server/entry.sh
+++ b/images/code-server/entry.sh
@@ -3,26 +3,60 @@ set -e
 
 if [ -z "${TUNNEL_TOKEN}" ]; then
     echo "❌ Error: TUNNEL_TOKEN is required"
-    echo "Get it from Cloudflare Zero Trust dashboard or 'cloudflared tunnel create'"
+    echo "Get it from the Cloudflare Zero Trust dashboard or by running 'cloudflared tunnel token <tunnel-name>'"
     exit 1
 fi
 
-SSH_PASSWORD=${SSH_PASSWORD:-changeme}
-CS_PASSWORD=${CS_PASSWORD:-changeme}
+if [ -z "${CS_PASSWORD}" ]; then
+    echo "❌ Error: CS_PASSWORD is required"
+    exit 1
+fi
+
+if [ -z "${SSH_PASSWORD}" ] && [ -z "${SSH_AUTHORIZED_KEYS}" ]; then
+    echo "❌ Error: At least one of SSH_PASSWORD or SSH_AUTHORIZED_KEYS is required"
+    exit 1
+fi
+
 CS_PORT=${CS_PORT:-8080}
 
-echo "root:${SSH_PASSWORD}" | chpasswd
+if [ -n "${SSH_PASSWORD}" ]; then
+    echo "coder:${SSH_PASSWORD}" | chpasswd
+    sed -i 's/#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+fi
 
-sed -i "s/#*Port .*/Port 22/" /etc/ssh/sshd_config
+if [ -n "${SSH_AUTHORIZED_KEYS}" ]; then
+    mkdir -p /home/coder/.ssh
+    chmod 700 /home/coder/.ssh
+    echo "${SSH_AUTHORIZED_KEYS}" > /home/coder/.ssh/authorized_keys
+    chmod 600 /home/coder/.ssh/authorized_keys
+    chown -R coder:coder /home/coder/.ssh
+fi
 
 echo "🚀 Starting SSH server..."
-/usr/sbin/sshd
+/usr/sbin/sshd -D &
+SSHD_PID=$!
 
 echo "🖥️ Starting code-server on port ${CS_PORT}..."
 PASSWORD="${CS_PASSWORD}" code-server \
     --bind-addr "0.0.0.0:${CS_PORT}" \
     --auth password \
     --disable-telemetry &
+CODE_SERVER_PID=$!
 
 echo "🌐 Starting Cloudflare Tunnel..."
-exec cloudflared tunnel --no-autoupdate run --token "${TUNNEL_TOKEN}"
+cloudflared tunnel --no-autoupdate run --token "${TUNNEL_TOKEN}" &
+CLOUDFLARED_PID=$!
+
+PIDS=("$SSHD_PID" "$CODE_SERVER_PID" "$CLOUDFLARED_PID")
+
+trap 'echo "Signal received, stopping services..."; kill "${PIDS[@]}" 2>/dev/null; wait "${PIDS[@]}" 2>/dev/null; exit 0' TERM INT
+
+echo "✅ All services started (SSHD=${SSHD_PID}, CODE_SERVER=${CODE_SERVER_PID}, CLOUDFLARED=${CLOUDFLARED_PID})"
+
+set +e
+wait -n "${PIDS[@]}"
+EXIT_CODE=$?
+echo "❌ A service exited with status ${EXIT_CODE}, stopping remaining services..."
+kill "${PIDS[@]}" 2>/dev/null
+wait "${PIDS[@]}" 2>/dev/null
+exit "${EXIT_CODE}"


### PR DESCRIPTION
## Summary

Add a new `code-server` Docker image based on `debian:12-slim` that provides a browser-based VS Code environment accessible via Cloudflare Tunnel.

### Features
- **code-server**: Browser-based VS Code from [coder/code-server](https://github.com/coder/code-server)
- **Cloudflare Tunnel**: Secure remote access via cloudflared (no exposed ports needed)
- **SSH**: Built-in SSH server for terminal access
- **Pre-installed extensions**: Go, Python, ESLint, Prettier, Markdown All in One, GitHub Copilot/Chat, OpenCode

### Environment Variables
| Variable | Description | Default |
|----------|-------------|---------|
| `TUNNEL_TOKEN` | Cloudflare Tunnel token (**required**) | - |
| `SSH_PASSWORD` | Root SSH password | `changeme` |
| `CS_PASSWORD` | code-server web UI password | `changeme` |
| `CS_PORT` | code-server listen port | `8080` |

### Usage
Configure Cloudflare Zero Trust public hostname to point to `http://localhost:8080` for web access and `ssh://localhost:22` for SSH access.